### PR TITLE
3 changes in space charge of electron beam

### DIFF
--- a/src/xEbeam.cpp
+++ b/src/xEbeam.cpp
@@ -980,8 +980,8 @@ vectorU xEbeam::UniCilinder(xTime &t, vectorU &ion) // models electron beam like
 
       if (rc() > 0.)
       {
-         ion_new[1] += Vdr * ion_new[2] / rc;
-         ion_new[3] += Vdr * ion_new[0] / rc;
+         ion_new[1] += Vdr * -ion_new[2] / rc;
+         ion_new[3] += Vdr *  ion_new[0] / rc;
       }
    }
 

--- a/src/xEbeam.cpp
+++ b/src/xEbeam.cpp
@@ -976,12 +976,12 @@ vectorU xEbeam::UniCilinder(xTime &t, vectorU &ion) // models electron beam like
       Vdr = UC_Vdrift(rc, bcurrent, bradius);
 
       // F.Ttemp += Vdr * Vdr * E_e / 2.;
-      // F.V_tr_e = (F.Ttemp / U_me + (dVdr * rc * dVdr * rc)) ^ 0.5;
+      F.V_tr_e = (F.Ttemp / U_me + (dVdr * rc * dVdr * rc)) ^ 0.5;
 
       if (rc() > 0.)
       {
-         ion_new[1] += Vdr * -ion_new[2] / rc;
-         ion_new[3] += Vdr *  ion_new[0] / rc;
+         ion_new[1] -= Vdr * ion_new[2] / rc;
+         ion_new[3] -= Vdr * ion_new[0] / rc;
       }
    }
 

--- a/src/xEbeam.cpp
+++ b/src/xEbeam.cpp
@@ -836,10 +836,10 @@ doubleU xEbeam::UC_dp_P(doubleU r, doubleU Ie, doubleU Re) // calculates momentu
 doubleU xEbeam::UC_Vdrift(doubleU r, doubleU Ie, doubleU Re) // calculates drift angle (drift velocity over long. velocity) for Uniformely distr. cilinder
 {
    if (U_Abs(r) <= Re)
-      return (1. - (Neutralization * e_Energy.Gamma2)) *
+      return (1. - Neutralization) *
              2. * U_Abs(r) * Ie / (U_c * F.mfield * Re * Re * e_Energy.Gamma2 * e_Energy.Beta2);
    else
-      return (1. - (Neutralization * e_Energy.Gamma2)) *
+      return (1. - Neutralization) *
              2. * Ie / (U_c * F.mfield * U_Abs(r) * e_Energy.Gamma2 * e_Energy.Beta2);
 }
 //---------------------------------------------------------------------------

--- a/src/xEbeam.cpp
+++ b/src/xEbeam.cpp
@@ -975,8 +975,8 @@ vectorU xEbeam::UniCilinder(xTime &t, vectorU &ion) // models electron beam like
       ion_new[5] -= UC_dp_P(rc, bcurrent, bradius);
       Vdr = UC_Vdrift(rc, bcurrent, bradius);
 
-      F.Ttemp += Vdr * Vdr * E_e / 2.;
-      F.V_tr_e = (F.Ttemp / U_me + (dVdr * rc * dVdr * rc)) ^ 0.5;
+      // F.Ttemp += Vdr * Vdr * E_e / 2.;
+      // F.V_tr_e = (F.Ttemp / U_me + (dVdr * rc * dVdr * rc)) ^ 0.5;
 
       if (rc() > 0.)
       {


### PR DESCRIPTION
1. Disabled unknown effect of electron beam rotation on the electron temperature
2. Wrong sign in electron beam rotation due to space charge
3. Removed gamma*gamma from inside the neutralization term. This was causing the space charge not to be completely neutralized